### PR TITLE
Pivot user-facing app to contests, portfolio, and trading

### DIFF
--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -9,9 +9,7 @@ import { AuthGuard } from "./core/auth/guards/auth.guard";
 export const routes: Routes = [
   { path: '', pathMatch: 'full', redirectTo: 'dashboard' },
 
-  // Admin console — standalone (not wrapped in LayoutComponent so the admin
-  // module owns its own shell). Access is gated by AdminGuard inside the
-  // module; in dev bypass mode (environment.devBypassAuth) it opens freely.
+  // Admin console
   {
     path: 'admin',
     loadChildren: () => import('./modules/admin/admin.module').then(m => m.AdminModule)
@@ -31,16 +29,16 @@ export const routes: Routes = [
     ]
   },
 
-  // Auth routes for authenticated users
+  // Authenticated routes
   {
     path: '',
     component: LayoutComponent,
     canActivate:[AuthGuard],
     children: [
       { path: 'dashboard', loadChildren: () => import('./modules/dashboard/dashboard.module').then(m => m.DashboardModule) },
-      { path: 'dispensary', loadChildren: () => import('./modules/dispensary-profile/dispensary-profile.module').then(m => m.DispensaryProfileModule)},
-      { path: 'deals', loadChildren: ()=>import('./modules/deals/deals.module').then(m => m.DealsModule)},
-      { path: 'chat', loadChildren: () => import('./modules/chat/chat.module').then(m => m.ChatModule)}
+      { path: 'contests', loadChildren: () => import('./modules/contests/contests.module').then(m => m.ContestsModule) },
+      { path: 'portfolio', loadChildren: () => import('./modules/portfolio/portfolio.module').then(m => m.PortfolioModule) },
+      { path: 'trading', loadChildren: () => import('./modules/trading/trading.module').then(m => m.TradingModule) }
     ]
   }
 ];

--- a/src/app/core/auth/auth.service.ts
+++ b/src/app/core/auth/auth.service.ts
@@ -124,26 +124,15 @@ export class AuthService {
             return throwError(() => new Error('User is already logged in.'));
         }
 
-        return this._httpClient.post<ApiResponse>(`${environment.baseUrl}/web/auth/dispensary/signin`, credentials).pipe(
-            switchMap((response: ApiResponse) => {
-                
-                // Store the access token in the local storage
+        return this._httpClient.post<any>(`${environment.baseUrl}/api/auth/login`, credentials).pipe(
+            switchMap((response: any) => {
                 this.accessToken = response.token;
-
-                // Set the authenticated flag to true
                 this._authenticated = true;
-
-                // Account type 
-                this.accountType = response.data.dispensaryType;
-
-                this.accountId = this.accountType === 'main' ? response.data.dispensaryId : response.data.accountId;
-                this.accountUsername = this.accountType === 'main' ? response.data.dispensaryName : response.data.accountUsername;
-
-                // Store the dispensary id on the dispensary service
-                this._dispensaryService.dispensaryId = response.data.dispensaryId;
-                this._dispensaryService.dispensaryName = response.data.dispensaryName;
-
-                // Return a new observable with the response
+                this.accountType = 'main';
+                this.accountId = response.user_id;
+                this.accountUsername = response.name;
+                this._dispensaryService.dispensaryId = response.user_id;
+                this._dispensaryService.dispensaryName = response.name;
                 return of(response);
             }),
             catchError(err => of(err))

--- a/src/app/core/contest/contest.service.ts
+++ b/src/app/core/contest/contest.service.ts
@@ -1,0 +1,29 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+
+@Injectable({ providedIn: 'root' })
+export class ContestService {
+  constructor(private http: HttpClient) {}
+
+  list(): Observable<any> {
+    return this.http.get(`${environment.baseUrl}/api/contests`);
+  }
+
+  get(contestId: string): Observable<any> {
+    return this.http.get(`${environment.baseUrl}/api/contests/${contestId}`);
+  }
+
+  getLeaderboard(contestId: string): Observable<any> {
+    return this.http.get(`${environment.baseUrl}/api/contests/${contestId}/leaderboard`);
+  }
+
+  getParticipants(contestId: string): Observable<any> {
+    return this.http.get(`${environment.baseUrl}/api/contests/${contestId}/participants`);
+  }
+
+  join(contestId: string): Observable<any> {
+    return this.http.post(`${environment.baseUrl}/api/contests/${contestId}/join`, {});
+  }
+}

--- a/src/app/core/portfolio/portfolio.service.ts
+++ b/src/app/core/portfolio/portfolio.service.ts
@@ -1,0 +1,21 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+
+@Injectable({ providedIn: 'root' })
+export class PortfolioService {
+  constructor(private http: HttpClient) {}
+
+  getPortfolio(userId: string): Observable<any> {
+    return this.http.get(`${environment.baseUrl}/api/portfolio/${userId}`);
+  }
+
+  executeTrade(userId: string, trade: any): Observable<any> {
+    return this.http.post(`${environment.baseUrl}/api/portfolio/${userId}/trade`, trade);
+  }
+
+  getTransactions(userId: string): Observable<any> {
+    return this.http.get(`${environment.baseUrl}/api/portfolio/${userId}/transactions`);
+  }
+}

--- a/src/app/layout/layout.component.css
+++ b/src/app/layout/layout.component.css
@@ -1,4 +1,11 @@
-.beanstalk-content {
-    height: 100%;
-    margin: 0;
+.layout {
+    display: flex;
+    min-height: 100vh;
+}
+
+.main-content {
+    flex: 1;
+    background: #FAFAFA;
+    overflow-y: auto;
+    height: 100vh;
 }

--- a/src/app/layout/layout.component.html
+++ b/src/app/layout/layout.component.html
@@ -1,8 +1,6 @@
-<section class="beanstalk-content grid yBackgroundGray">
+<div class="layout">
     <app-sidebar></app-sidebar>
-    <!-- Content -->
-    <section class="col">        
-        <app-header></app-header>
+    <main class="main-content">
         <router-outlet></router-outlet>
-    </section>
-</section>
+    </main>
+</div>

--- a/src/app/layout/sidebar/sidebar.component.css
+++ b/src/app/layout/sidebar/sidebar.component.css
@@ -1,4 +1,148 @@
-:host section {
-    width: 200px;
+.sidebar {
+    width: 260px;
+    min-height: 100vh;
+    background: #1B5E20;
+    display: flex;
+    flex-direction: column;
+}
+
+.sidebar-inner {
+    display: flex;
+    flex-direction: column;
     height: 100%;
+    padding: 0;
+}
+
+.sidebar-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 20px 24px;
+    border-bottom: 1px solid rgba(255,255,255,0.1);
+}
+
+.sidebar-logo {
+    font-size: 24px;
+}
+
+.sidebar-brand {
+    font-size: 20px;
+    font-weight: 700;
+    color: #fff;
+    letter-spacing: -0.5px;
+}
+
+.sidebar-nav {
+    flex: 1;
+    padding: 16px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.nav-section {
+    font-size: 11px;
+    font-weight: 600;
+    color: rgba(255,255,255,0.4);
+    letter-spacing: 1px;
+    padding: 8px 12px 12px;
+    text-transform: uppercase;
+}
+
+.nav-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 12px;
+    border-radius: 8px;
+    color: rgba(255,255,255,0.75);
+    text-decoration: none;
+    font-size: 14px;
+    font-weight: 500;
+    transition: all 0.15s ease;
+    cursor: pointer;
+}
+
+.nav-item:hover {
+    background: rgba(255,255,255,0.1);
+    color: #fff;
+}
+
+.nav-item.active {
+    background: #fff;
+    color: #1B5E20;
+    font-weight: 600;
+    border-left: 3px solid #4CAF50;
+}
+
+.nav-icon {
+    font-size: 18px;
+    width: 24px;
+    text-align: center;
+}
+
+.nav-label {
+    font-size: 14px;
+}
+
+.sidebar-footer {
+    padding: 16px;
+    border-top: 1px solid rgba(255,255,255,0.1);
+}
+
+.user-info {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 4px;
+    margin-bottom: 8px;
+}
+
+.user-avatar {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: #4CAF50;
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 13px;
+    font-weight: 700;
+}
+
+.user-details {
+    display: flex;
+    flex-direction: column;
+}
+
+.user-name {
+    color: #fff;
+    font-size: 13px;
+    font-weight: 600;
+}
+
+.user-role {
+    color: rgba(255,255,255,0.5);
+    font-size: 11px;
+}
+
+.logout-btn {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 8px 12px;
+    background: none;
+    border: none;
+    border-radius: 6px;
+    color: rgba(255,255,255,0.6);
+    font-size: 13px;
+    cursor: pointer;
+    transition: all 0.15s ease;
+}
+
+.logout-btn:hover {
+    background: rgba(255,255,255,0.1);
+    color: #fff;
 }

--- a/src/app/layout/sidebar/sidebar.component.html
+++ b/src/app/layout/sidebar/sidebar.component.html
@@ -1,33 +1,46 @@
 <!-- SideBar -->
-<section class="col-fixed yBackgroundGreen" >
-
-    <div class="grid flex-column">
-        <!-- Icon -->
-        <div class="col-12 flex justify-content-center mt-2">
-            <img src="/assets/logo_beanstalk_horizontal.png" width="150px">
+<section class="sidebar">
+    <div class="sidebar-inner">
+        <!-- Logo -->
+        <div class="sidebar-header">
+            <span class="sidebar-logo">🌱</span>
+            <span class="sidebar-brand">Beanstalk</span>
         </div>
 
-
-        <!-- Menu -->
-        <div class="col-12 mt-5">
-            <div class="grid">
-                <div class="col-12 p-4">
-                    <p style="color: #fbff14; font-size: 14px;" [routerLink]="['/dashboard']"><b>Dashboard</b></p>
-                    <p class="mt-3 ml-6" style="color: #ffffff; font-size: 14px; margin-top: 15px;cursor: pointer;" [routerLink]="['/dispensary/profile']">Profile</p>
-                    <p class="mt-3 ml-6" style="color: #ffffff; font-size: 14px; margin-top: 15px;cursor: pointer;" [routerLink]="['/deals']">Deals</p>
-                    <p class="mt-3 ml-6" style="color: #ffffff; font-size: 14px; margin-top: 15px;cursor: pointer;" [routerLink]="['/chat']">Chat</p>
-                </div>
-            </div>
-        </div>        
+        <!-- Navigation -->
+        <nav class="sidebar-nav">
+            <span class="nav-section">NAVIGATION</span>
+            <a class="nav-item" routerLink="/dashboard" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
+                <span class="nav-icon">📊</span>
+                <span class="nav-label">Dashboard</span>
+            </a>
+            <a class="nav-item" routerLink="/contests" routerLinkActive="active">
+                <span class="nav-icon">🏆</span>
+                <span class="nav-label">Contests</span>
+            </a>
+            <a class="nav-item" routerLink="/portfolio" routerLinkActive="active">
+                <span class="nav-icon">📈</span>
+                <span class="nav-label">Portfolio</span>
+            </a>
+            <a class="nav-item" routerLink="/trading" routerLinkActive="active">
+                <span class="nav-icon">💰</span>
+                <span class="nav-label">Trading</span>
+            </a>
+        </nav>
 
         <!-- Footer -->
-        <div class="flex justify-content-center position-absolute bottom-0 mx-4">
-            <div pRipple class="p-ripple.orange flex-wrap">
-                <small style="color: #ffffff;"> &copy; 2022 Beanstalk,Inc. -</small>
-                <small style="color: #E19A3D;"> {{version}}</small>
+        <div class="sidebar-footer">
+            <div class="user-info">
+                <div class="user-avatar">{{ initials }}</div>
+                <div class="user-details">
+                    <span class="user-name">{{ userName }}</span>
+                    <span class="user-role">Investor</span>
+                </div>
             </div>
-        </div>        
+            <button class="logout-btn" (click)="logout()">
+                <span>🚪</span>
+                <span class="nav-label">Logout</span>
+            </button>
+        </div>
     </div>
-
 </section>
-<!-- End-Sidebar -->

--- a/src/app/layout/sidebar/sidebar.component.ts
+++ b/src/app/layout/sidebar/sidebar.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { AuthService } from 'src/app/core/auth/auth.service';
-import { environment } from 'src/environments/environment';
 
 @Component({
   selector: 'app-sidebar',
@@ -9,11 +8,19 @@ import { environment } from 'src/environments/environment';
   styleUrls: ['./sidebar.component.css']
 })
 export class SidebarComponent implements OnInit {
+  userName = '';
+  initials = '';
 
-  version: string = '';
-  constructor(private router: Router, private _authService: AuthService) { }
+  constructor(private router: Router, private authService: AuthService) {}
 
   ngOnInit(): void {
-    this.version = environment.version;
+    this.userName = this.authService.accountUsername || '';
+    const parts = this.userName.split(' ');
+    this.initials = parts.map(p => p[0]).join('').toUpperCase().substring(0, 2);
+  }
+
+  logout(): void {
+    this.authService.signOut();
+    this.router.navigateByUrl('/sign-in');
   }
 }

--- a/src/app/modules/admin/contest-manager/contest-manager.component.html
+++ b/src/app/modules/admin/contest-manager/contest-manager.component.html
@@ -64,7 +64,7 @@
           <span class="stat-label">Players</span>
         </div>
         <div class="stat">
-          <span class="stat-value">{{ getDuration(c) }}</span>
+          <span class="stat-value">{{ getDuration(c) }}<span *ngIf="getTimezoneShort(c)"> · {{ getTimezoneShort(c) }}</span></span>
           <span class="stat-label">Duration</span>
         </div>
         <div class="stat">
@@ -198,6 +198,12 @@
             <label>End Date *</label>
             <input type="datetime-local" [(ngModel)]="newContest.end_date" name="end_date" required />
           </div>
+        </div>
+        <div class="field">
+          <label>Timezone</label>
+          <select [(ngModel)]="newContest.timezone" name="timezone">
+            <option *ngFor="let tz of timezoneOptions" [value]="tz.value">{{ tz.label }}</option>
+          </select>
         </div>
       </fieldset>
 

--- a/src/app/modules/admin/contest-manager/contest-manager.component.ts
+++ b/src/app/modules/admin/contest-manager/contest-manager.component.ts
@@ -59,10 +59,20 @@ export class ContestManagerComponent implements OnInit {
     prizes: [] as any[],
     max_participants: 100,
     visibility: 'public',
+    timezone: 'America/New_York',
     sponsor_name: '',
     sponsor_logo_url: '',
     sponsor_tagline: ''
   };
+
+  timezoneOptions = [
+    { value: 'America/New_York',    label: 'Eastern Time (ET)' },
+    { value: 'America/Chicago',     label: 'Central Time (CT)' },
+    { value: 'America/Denver',      label: 'Mountain Time (MT)' },
+    { value: 'America/Los_Angeles', label: 'Pacific Time (PT)' },
+    { value: 'Pacific/Honolulu',    label: 'Hawaii (HT)' },
+    { value: 'UTC',                 label: 'UTC' },
+  ];
 
   // Notification form
   showNotificationForm = false;
@@ -163,6 +173,7 @@ export class ContestManagerComponent implements OnInit {
       prizes: [],
       max_participants: 100,
       visibility: 'public',
+      timezone: 'America/New_York',
       sponsor_name: '',
       sponsor_logo_url: '',
       sponsor_tagline: ''
@@ -198,11 +209,27 @@ export class ContestManagerComponent implements OnInit {
   }
 
   getDuration(contest: Contest): string {
+    if (!contest.start_date || !contest.end_date) return '—';
     const start = new Date(contest.start_date);
     const end = new Date(contest.end_date);
+    if (isNaN(start.getTime()) || isNaN(end.getTime())) return '—';
     const days = Math.ceil((end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24));
-    if (days <= 0) return '—';
+    if (days <= 0 || isNaN(days)) return '—';
     return days === 1 ? '1 day' : `${days} days`;
+  }
+
+  getTimezoneShort(contest: any): string {
+    const tz = contest.timezone;
+    if (!tz) return '';
+    const map: Record<string, string> = {
+      'America/New_York': 'ET',
+      'America/Chicago': 'CT',
+      'America/Denver': 'MT',
+      'America/Los_Angeles': 'PT',
+      'Pacific/Honolulu': 'HT',
+      'UTC': 'UTC',
+    };
+    return map[tz] || tz;
   }
 
   getStatusLabel(status: string): string {

--- a/src/app/modules/auth/sign-in/sign-in.component.html
+++ b/src/app/modules/auth/sign-in/sign-in.component.html
@@ -21,17 +21,17 @@
                         <i class="pi pi-user"></i>
                     </span>
                     <span class="p-float-label">
-                        <input pInputText type="email" class="mr-2" formControlName="dispensary_email" />
+                        <input pInputText type="email" class="mr-2" formControlName="email" />
                         <label for="inputgroup">Email</label>
                     </span>
                 </div>
 
                 <span style="margin-top: 5px;">
                     <p-message severity="error" [style]="{height: '20px'}" class="mr-2"
-                        *ngIf="(signInFormControl['dispensary_email'].errors?.['required'] && signInFormControl['dispensary_email'].touched)"
+                        *ngIf="(signInFormControl['email'].errors?.['required'] && signInFormControl['email'].touched)"
                         text="Email is required"></p-message>
                     <p-message severity="error" [style]="{height: '20px'}" class="mr-2"
-                        *ngIf="(signInFormControl['dispensary_email'].errors?.['email'] && signInFormControl['dispensary_email'].touched)"
+                        *ngIf="(signInFormControl['email'].errors?.['email'] && signInFormControl['email'].touched)"
                         text="Format is invalid"></p-message>
                 </span>
 
@@ -40,18 +40,18 @@
                         <i class="pi pi-lock"></i>
                     </span>
                     <span class="p-float-label">
-                        <input pInputText type="password" class="mr-2" formControlName="dispensary_password" />
+                        <input pInputText type="password" class="mr-2" formControlName="password" />
                         <label for="inputgroup">Password</label>
                     </span>
                 </div>
 
                 <span style="margin-top: 5px;">
                     <p-message severity="error" [style]="{height: '20px'}" class="mr-2"
-                        *ngIf="(signInFormControl['dispensary_password'].errors?.['required'] && signInFormControl['dispensary_password'].touched)"
+                        *ngIf="(signInFormControl['password'].errors?.['required'] && signInFormControl['password'].touched)"
                         text="Password is required">
                     </p-message>
                     <p-message severity="error" [style]="{height: '20px'}" class="mr-2"
-                        *ngIf="(signInFormControl['dispensary_password'].errors?.['pattern'] && signInFormControl['dispensary_password'].touched)"
+                        *ngIf="(signInFormControl['password'].errors?.['pattern'] && signInFormControl['password'].touched)"
                         text="Password must be at least 6 characters"></p-message>
                 </span>
             </div>

--- a/src/app/modules/auth/sign-in/sign-in.component.ts
+++ b/src/app/modules/auth/sign-in/sign-in.component.ts
@@ -29,8 +29,8 @@ export class SignInComponent implements OnInit {
 
   ngOnInit(): void {
     this.signInForm = this._formBuilder.group({
-      dispensary_email: ['', [Validators.required, Validators.email]],
-      dispensary_password: ['', Validators.required],
+      email: ['', [Validators.required, Validators.email]],
+      password: ['', Validators.required],
       remember_me: [false]
     });
   }

--- a/src/app/modules/contests/contest-detail.component.html
+++ b/src/app/modules/contests/contest-detail.component.html
@@ -1,0 +1,103 @@
+<div class="p-4" *ngIf="contest">
+    <!-- Back link -->
+    <div class="mb-3">
+        <a [routerLink]="['/contests']" style="color: #057671; text-decoration: none; font-size: 14px;">
+            <i class="pi pi-arrow-left mr-1"></i> Back to Contests
+        </a>
+    </div>
+
+    <!-- Contest Header -->
+    <div class="flex justify-content-between align-items-start mb-4">
+        <div>
+            <h2 style="color: #057671; margin: 0;">{{ contest.name }}</h2>
+            <p style="color: #808080; margin-top: 8px;">{{ contest.description }}</p>
+        </div>
+        <div class="flex align-items-center gap-2">
+            <p-badge [value]="contest.status | titlecase"
+                     [severity]="contest.status === 'active' ? 'success' : contest.status === 'concluded' ? 'info' : 'warning'"></p-badge>
+        </div>
+    </div>
+
+    <!-- Contest Stats -->
+    <div class="grid mb-4">
+        <div class="col-12 md:col-3">
+            <p-card>
+                <div class="flex flex-column align-items-center">
+                    <span style="color: #808080; font-size: 13px;">Players</span>
+                    <span style="font-size: 28px; font-weight: bold; color: #057671;">{{ contest.participants }}</span>
+                    <span style="font-size: 12px; color: #aaa;">of {{ contest.max_participants }}</span>
+                </div>
+            </p-card>
+        </div>
+        <div class="col-12 md:col-3">
+            <p-card>
+                <div class="flex flex-column align-items-center">
+                    <span style="color: #808080; font-size: 13px;">Starting Balance</span>
+                    <span style="font-size: 28px; font-weight: bold; color: #057671;">{{ contest.starting_balance | currency }}</span>
+                </div>
+            </p-card>
+        </div>
+        <div class="col-12 md:col-3">
+            <p-card>
+                <div class="flex flex-column align-items-center">
+                    <span style="color: #808080; font-size: 13px;">Days Remaining</span>
+                    <span style="font-size: 28px; font-weight: bold; color: #057671;">{{ getDaysRemaining() }}</span>
+                </div>
+            </p-card>
+        </div>
+        <div class="col-12 md:col-3" *ngIf="contest.sponsor_name">
+            <p-card>
+                <div class="flex flex-column align-items-center">
+                    <span style="color: #808080; font-size: 13px;">Sponsor</span>
+                    <div class="flex align-items-center gap-2 mt-1">
+                        <img [src]="contest.sponsor_logo_url" width="24" height="24" style="border-radius: 4px;" *ngIf="contest.sponsor_logo_url">
+                        <span style="font-size: 18px; font-weight: bold; color: #057671;">{{ contest.sponsor_name }}</span>
+                    </div>
+                    <span style="font-size: 12px; color: #aaa;" *ngIf="contest.sponsor_tagline">{{ contest.sponsor_tagline }}</span>
+                </div>
+            </p-card>
+        </div>
+    </div>
+
+    <!-- Leaderboard -->
+    <h3 style="color: #057671;"><i class="pi pi-chart-bar mr-2"></i>Leaderboard</h3>
+    <p-table [value]="allRankings" styleClass="p-datatable-sm p-datatable-striped" class="mt-2"
+             *ngIf="allRankings.length > 0; else noLeaderboard">
+        <ng-template pTemplate="header">
+            <tr>
+                <th style="width: 80px;">Rank</th>
+                <th>Player</th>
+                <th>Age Group</th>
+                <th>Portfolio Value</th>
+                <th>Return</th>
+                <th>Positions</th>
+            </tr>
+        </ng-template>
+        <ng-template pTemplate="body" let-r>
+            <tr>
+                <td>
+                    <div class="flex align-items-center gap-2">
+                        <i *ngIf="getRankIcon(r.rank)" [class]="getRankIcon(r.rank)" [style.color]="getRankColor(r.rank)"></i>
+                        <b>{{ r.rank }}</b>
+                    </div>
+                </td>
+                <td>{{ r.username || r.user_id | slice:0:8 }}</td>
+                <td>
+                    <p-chip [label]="formatAgeGroup(r.age_group)" styleClass="p-chip-sm"></p-chip>
+                </td>
+                <td><b>{{ r.portfolio_value | currency }}</b></td>
+                <td [class]="getReturnClass(r.return_percent)">
+                    <b>{{ r.return_percent > 0 ? '+' : '' }}{{ r.return_percent | number:'1.2-2' }}%</b>
+                </td>
+                <td>{{ r.position_count }}</td>
+            </tr>
+        </ng-template>
+    </p-table>
+    <ng-template #noLeaderboard>
+        <p style="color: #808080; margin-top: 10px;">No leaderboard data yet.</p>
+    </ng-template>
+</div>
+
+<div class="p-4 flex justify-content-center" *ngIf="loading">
+    <p-progressSpinner></p-progressSpinner>
+</div>

--- a/src/app/modules/contests/contest-detail.component.ts
+++ b/src/app/modules/contests/contest-detail.component.ts
@@ -1,0 +1,83 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { ContestService } from 'src/app/core/contest/contest.service';
+
+@Component({
+    selector: 'app-contest-detail',
+    templateUrl: 'contest-detail.component.html'
+})
+export class ContestDetailComponent implements OnInit {
+    contest: any = null;
+    leaderboard: any = null;
+    allRankings: any[] = [];
+    loading = true;
+
+    constructor(
+        private route: ActivatedRoute,
+        private contestService: ContestService
+    ) {}
+
+    ngOnInit(): void {
+        const id = this.route.snapshot.paramMap.get('id')!;
+
+        this.contestService.get(id).subscribe({
+            next: (res: any) => {
+                this.contest = res;
+                this.loading = false;
+            },
+            error: () => this.loading = false
+        });
+
+        this.contestService.getLeaderboard(id).subscribe({
+            next: (res: any) => {
+                this.leaderboard = res.leaderboards || {};
+                this.allRankings = this.flattenRankings(this.leaderboard);
+            },
+            error: () => {}
+        });
+    }
+
+    private flattenRankings(leaderboards: any): any[] {
+        const rankings: any[] = [];
+        for (const ageGroup of Object.keys(leaderboards)) {
+            const board = leaderboards[ageGroup];
+            if (board?.rankings) {
+                for (const r of board.rankings) {
+                    rankings.push({ ...r, age_group: ageGroup });
+                }
+            }
+        }
+        return rankings.sort((a, b) => a.rank - b.rank);
+    }
+
+    getReturnClass(val: number): string {
+        if (val > 0) return 'text-green-600';
+        if (val < 0) return 'text-red-600';
+        return '';
+    }
+
+    getRankIcon(rank: number): string {
+        if (rank === 1) return 'pi pi-star-fill';
+        if (rank === 2) return 'pi pi-star';
+        if (rank === 3) return 'pi pi-star';
+        return '';
+    }
+
+    getRankColor(rank: number): string {
+        if (rank === 1) return '#FFD700';
+        if (rank === 2) return '#C0C0C0';
+        if (rank === 3) return '#CD7F32';
+        return 'transparent';
+    }
+
+    formatAgeGroup(group: string): string {
+        return group.replace('_', ' ').replace(/\b\w/g, c => c.toUpperCase());
+    }
+
+    getDaysRemaining(): number {
+        if (!this.contest?.end_date) return 0;
+        const now = new Date().getTime();
+        const end = new Date(this.contest.end_date).getTime();
+        return Math.max(0, Math.ceil((end - now) / (1000 * 60 * 60 * 24)));
+    }
+}

--- a/src/app/modules/contests/contest-list.component.css
+++ b/src/app/modules/contests/contest-list.component.css
@@ -1,0 +1,245 @@
+.cm-page {
+    padding: 32px 40px;
+    max-width: 1400px;
+}
+
+.cm-header h1 {
+    font-size: 28px;
+    font-weight: 700;
+    color: #212121;
+    margin: 0;
+}
+
+.subtitle {
+    color: #9E9E9E;
+    font-size: 14px;
+    margin-top: 4px;
+}
+
+.cm-filters {
+    display: flex;
+    gap: 8px;
+    margin: 24px 0;
+}
+
+.chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 18px;
+    border-radius: 20px;
+    border: 1.5px solid #E0E0E0;
+    background: #fff;
+    color: #616161;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.15s ease;
+}
+
+.chip:hover {
+    border-color: #2E7D32;
+    color: #2E7D32;
+}
+
+.chip.active {
+    background: #2E7D32;
+    color: #fff;
+    border-color: #2E7D32;
+}
+
+.dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    display: inline-block;
+}
+
+.dot-active { background: #4CAF50; }
+.dot-draft { background: #9E9E9E; }
+.dot-ended { background: #1E88E5; }
+
+.chip.active .dot-active,
+.chip.active .dot-draft,
+.chip.active .dot-ended {
+    background: #fff;
+}
+
+.cards-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+    gap: 20px;
+}
+
+.card {
+    position: relative;
+    background: #fff;
+    border: 1.5px solid #EEEEEE;
+    border-radius: 10px;
+    padding: 24px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+}
+
+.card:hover {
+    border-color: #2E7D32;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+    transform: translateY(-2px);
+}
+
+.badge-status {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    padding: 4px 12px;
+    border-radius: 12px;
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: #fff;
+}
+
+.badge-status--active { background: #2E7D32; }
+.badge-status--draft { background: #9E9E9E; }
+.badge-status--concluded { background: #1E88E5; }
+
+.card-title {
+    font-size: 18px;
+    font-weight: 700;
+    color: #212121;
+    margin: 0 0 8px;
+    padding-right: 80px;
+}
+
+.card-desc {
+    font-size: 13px;
+    color: #616161;
+    line-height: 1.5;
+    margin: 0 0 16px;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.card-sponsor {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 14px;
+    background: #F5F5F5;
+    border-radius: 8px;
+    margin-bottom: 16px;
+    font-size: 13px;
+    color: #616161;
+}
+
+.card-sponsor-logo {
+    width: 20px;
+    height: 20px;
+    border-radius: 4px;
+}
+
+.card-stats {
+    display: flex;
+    gap: 0;
+    margin-bottom: 16px;
+    border: 1px solid #EEEEEE;
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+.stat {
+    flex: 1;
+    text-align: center;
+    padding: 12px 8px;
+    border-right: 1px solid #EEEEEE;
+}
+
+.stat:last-child {
+    border-right: none;
+}
+
+.stat-value {
+    display: block;
+    font-size: 16px;
+    font-weight: 700;
+    color: #212121;
+}
+
+.stat-label {
+    display: block;
+    font-size: 10px;
+    font-weight: 600;
+    color: #9E9E9E;
+    letter-spacing: 0.5px;
+    margin-top: 2px;
+}
+
+.card-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 16px;
+}
+
+.tag {
+    padding: 3px 10px;
+    background: #E8F5E9;
+    color: #1B5E20;
+    border-radius: 20px;
+    font-size: 12px;
+    font-weight: 500;
+    text-transform: capitalize;
+}
+
+.card-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    border: none;
+    border-radius: 6px;
+    font-weight: 600;
+    font-size: 13px;
+    cursor: pointer;
+    transition: all 0.15s ease;
+}
+
+.btn-green {
+    background: #2E7D32;
+    color: #fff;
+    padding: 6px 14px;
+}
+
+.btn-green:hover {
+    background: #1B5E20;
+}
+
+.btn-ghost {
+    background: transparent;
+    color: #616161;
+    padding: 6px 14px;
+}
+
+.btn-ghost:hover {
+    background: #F5F5F5;
+}
+
+.btn-sm {
+    padding: 6px 14px;
+    font-size: 13px;
+}
+
+.loading {
+    display: flex;
+    justify-content: center;
+    padding: 60px;
+}

--- a/src/app/modules/contests/contest-list.component.html
+++ b/src/app/modules/contests/contest-list.component.html
@@ -1,0 +1,67 @@
+<div class="cm-page">
+    <header class="cm-header">
+        <div>
+            <h1>Contests</h1>
+            <p class="subtitle">Browse and join investment contests</p>
+        </div>
+    </header>
+
+    <!-- Filters -->
+    <div class="cm-filters">
+        <button class="chip" [class.active]="!statusFilter" (click)="statusFilter = ''">All</button>
+        <button class="chip" [class.active]="statusFilter === 'active'" (click)="statusFilter = 'active'">
+            <span class="dot dot-active"></span> Active
+        </button>
+        <button class="chip" [class.active]="statusFilter === 'draft'" (click)="statusFilter = 'draft'">
+            <span class="dot dot-draft"></span> Upcoming
+        </button>
+        <button class="chip" [class.active]="statusFilter === 'concluded'" (click)="statusFilter = 'concluded'">
+            <span class="dot dot-ended"></span> Concluded
+        </button>
+    </div>
+
+    <!-- Contest Cards -->
+    <div class="cards-grid" *ngIf="!loading">
+        <div class="card" *ngFor="let c of filteredContests" [routerLink]="['/contests', c.contest_id]">
+            <span class="badge-status" [ngClass]="'badge-status--' + c.status">
+                {{ c.status | titlecase }}
+            </span>
+
+            <h3 class="card-title">{{ c.name }}</h3>
+            <p class="card-desc">{{ c.description }}</p>
+
+            <div class="card-sponsor" *ngIf="c.sponsor_name">
+                <img [src]="c.sponsor_logo_url" alt="" class="card-sponsor-logo" *ngIf="c.sponsor_logo_url">
+                <span>Sponsored by <strong>{{ c.sponsor_name }}</strong></span>
+            </div>
+
+            <div class="card-stats">
+                <div class="stat">
+                    <span class="stat-value">{{ c.participants }}/{{ c.max_participants }}</span>
+                    <span class="stat-label">PLAYERS</span>
+                </div>
+                <div class="stat">
+                    <span class="stat-value">{{ getDuration(c) }} days</span>
+                    <span class="stat-label">DURATION</span>
+                </div>
+                <div class="stat">
+                    <span class="stat-value">${{ c.starting_balance | number }}</span>
+                    <span class="stat-label">STARTING $</span>
+                </div>
+            </div>
+
+            <div class="card-tags">
+                <span class="tag" *ngFor="let g of c.age_groups">{{ formatAgeGroup(g) }}</span>
+            </div>
+
+            <div class="card-actions">
+                <button class="btn btn-green btn-sm" *ngIf="c.status === 'draft'">Join</button>
+                <span class="btn btn-ghost btn-sm">Details →</span>
+            </div>
+        </div>
+    </div>
+
+    <div class="loading" *ngIf="loading">
+        <p-progressSpinner></p-progressSpinner>
+    </div>
+</div>

--- a/src/app/modules/contests/contest-list.component.ts
+++ b/src/app/modules/contests/contest-list.component.ts
@@ -1,0 +1,40 @@
+import { Component, OnInit } from '@angular/core';
+import { ContestService } from 'src/app/core/contest/contest.service';
+
+@Component({
+    selector: 'app-contest-list',
+    templateUrl: 'contest-list.component.html',
+    styleUrls: ['contest-list.component.css']
+})
+export class ContestListComponent implements OnInit {
+    contests: any[] = [];
+    loading = true;
+    statusFilter = '';
+
+    constructor(private contestService: ContestService) {}
+
+    ngOnInit(): void {
+        this.contestService.list().subscribe({
+            next: (res: any) => {
+                this.contests = res.contests || [];
+                this.loading = false;
+            },
+            error: () => this.loading = false
+        });
+    }
+
+    get filteredContests(): any[] {
+        if (!this.statusFilter) return this.contests;
+        return this.contests.filter(c => c.status === this.statusFilter);
+    }
+
+    getDuration(c: any): number {
+        const start = new Date(c.start_date).getTime();
+        const end = new Date(c.end_date).getTime();
+        return Math.ceil((end - start) / (1000 * 60 * 60 * 24));
+    }
+
+    formatAgeGroup(g: string): string {
+        return g.replace('_', ' ').replace(/\b\w/g, c => c.toUpperCase());
+    }
+}

--- a/src/app/modules/contests/contests.module.ts
+++ b/src/app/modules/contests/contests.module.ts
@@ -1,0 +1,18 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { PrimeNgModule } from 'src/app/shared/prime-ng.module';
+
+import { ContestListComponent } from './contest-list.component';
+import { ContestDetailComponent } from './contest-detail.component';
+import { contestsRoutes } from './contests.routing';
+
+@NgModule({
+    declarations: [ContestListComponent, ContestDetailComponent],
+    imports: [
+        CommonModule,
+        RouterModule.forChild(contestsRoutes),
+        PrimeNgModule
+    ]
+})
+export class ContestsModule {}

--- a/src/app/modules/contests/contests.routing.ts
+++ b/src/app/modules/contests/contests.routing.ts
@@ -1,0 +1,8 @@
+import { Route } from '@angular/router';
+import { ContestListComponent } from './contest-list.component';
+import { ContestDetailComponent } from './contest-detail.component';
+
+export const contestsRoutes: Route[] = [
+    { path: '', component: ContestListComponent },
+    { path: ':id', component: ContestDetailComponent }
+];

--- a/src/app/modules/dashboard/dashboard.component.css
+++ b/src/app/modules/dashboard/dashboard.component.css
@@ -1,0 +1,272 @@
+.dash-page {
+    padding: 32px 40px;
+    max-width: 1400px;
+}
+
+.dash-header h1 {
+    font-size: 28px;
+    font-weight: 700;
+    color: #212121;
+    margin: 0;
+}
+
+.subtitle {
+    color: #9E9E9E;
+    font-size: 14px;
+    margin-top: 4px;
+}
+
+.metrics-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 16px;
+    margin: 28px 0 36px;
+}
+
+.metric-card {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    background: #fff;
+    border: 1.5px solid #EEEEEE;
+    border-radius: 10px;
+    padding: 20px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+}
+
+.metric-icon {
+    width: 48px;
+    height: 48px;
+    border-radius: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 22px;
+}
+
+.contests-icon { background: #E8F5E9; }
+.portfolio-icon { background: #E0F2F1; }
+.total-icon { background: #E3F2FD; }
+.completed-icon { background: #FFF3E0; }
+
+.metric-label {
+    font-size: 12px;
+    font-weight: 600;
+    color: #9E9E9E;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.metric-value {
+    font-size: 28px;
+    font-weight: 700;
+    color: #212121;
+    margin-top: 2px;
+}
+
+.dash-section {
+    margin-bottom: 36px;
+}
+
+.section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 16px;
+}
+
+.section-header h2 {
+    font-size: 20px;
+    font-weight: 700;
+    color: #212121;
+    margin: 0;
+}
+
+.see-all {
+    color: #2E7D32;
+    font-size: 13px;
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.see-all:hover {
+    text-decoration: underline;
+}
+
+.cards-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+    gap: 20px;
+}
+
+.card {
+    position: relative;
+    background: #fff;
+    border: 1.5px solid #EEEEEE;
+    border-radius: 10px;
+    padding: 24px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+}
+
+.card:hover {
+    border-color: #2E7D32;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+    transform: translateY(-2px);
+}
+
+.badge-status {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    padding: 4px 12px;
+    border-radius: 12px;
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: #fff;
+}
+
+.badge-status--active { background: #2E7D32; }
+
+.card-title {
+    font-size: 18px;
+    font-weight: 700;
+    color: #212121;
+    margin: 0 0 8px;
+    padding-right: 80px;
+}
+
+.card-desc {
+    font-size: 13px;
+    color: #616161;
+    line-height: 1.5;
+    margin: 0 0 16px;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.card-sponsor {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 14px;
+    background: #F5F5F5;
+    border-radius: 8px;
+    margin-bottom: 16px;
+    font-size: 13px;
+    color: #616161;
+}
+
+.card-sponsor-logo {
+    width: 20px;
+    height: 20px;
+    border-radius: 4px;
+}
+
+.card-stats {
+    display: flex;
+    margin-bottom: 16px;
+    border: 1px solid #EEEEEE;
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+.stat {
+    flex: 1;
+    text-align: center;
+    padding: 12px 8px;
+    border-right: 1px solid #EEEEEE;
+}
+
+.stat:last-child { border-right: none; }
+
+.stat-value {
+    display: block;
+    font-size: 16px;
+    font-weight: 700;
+    color: #212121;
+}
+
+.stat-label {
+    display: block;
+    font-size: 10px;
+    font-weight: 600;
+    color: #9E9E9E;
+    letter-spacing: 0.5px;
+    margin-top: 2px;
+}
+
+.card-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.tag {
+    padding: 3px 10px;
+    background: #E8F5E9;
+    color: #1B5E20;
+    border-radius: 20px;
+    font-size: 12px;
+    font-weight: 500;
+    text-transform: capitalize;
+}
+
+.positions-table {
+    background: #fff;
+    border: 1.5px solid #EEEEEE;
+    border-radius: 10px;
+    overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+}
+
+.positions-table table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.positions-table thead {
+    background: #FAFAFA;
+}
+
+.positions-table th {
+    text-align: left;
+    padding: 12px 16px;
+    font-size: 11px;
+    font-weight: 600;
+    color: #9E9E9E;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    border-bottom: 1px solid #EEEEEE;
+}
+
+.positions-table td {
+    padding: 14px 16px;
+    font-size: 14px;
+    color: #212121;
+    border-bottom: 1px solid #F5F5F5;
+}
+
+.positions-table tr:last-child td {
+    border-bottom: none;
+}
+
+.symbol {
+    font-weight: 700;
+    font-family: 'SF Mono', 'Fira Code', monospace;
+}
+
+.positive {
+    color: #2E7D32;
+    font-weight: 600;
+}
+
+.negative {
+    color: #E53935;
+    font-weight: 600;
+}

--- a/src/app/modules/dashboard/dashboard.component.html
+++ b/src/app/modules/dashboard/dashboard.component.html
@@ -1,22 +1,114 @@
-<!-- Panel -->
-<div class="grid flex-column" style="height: 100%;">
-    <!-- Title-Panel -->
-    <div class="col-12 h-9rem p-7">
-        <h2>
-            <b>Hi {{ name }},</b> your collective data is all set
-        </h2>
-    </div>
-    <!-- Content-Panel -->
-    <div class="col-12 h-screen">
+<div class="dash-page">
+    <!-- Welcome -->
+    <header class="dash-header">
+        <div>
+            <h1>Welcome back, {{ name }}</h1>
+            <p class="subtitle">Here's what's happening with your contests and portfolio.</p>
+        </div>
+    </header>
 
-        <div class="grid align-items-center p-5 yBackgroundGray">
-            <p-card class="col-4" header="Profile" [style]="{'height': '15rem', 'cursor': 'pointer'}"
-                [routerLink]="['/dispensary/profile']"></p-card>
-            <p-card class="col-4" header="Chat" [style]="{'height': '15rem', 'cursor': 'pointer'}"
-                [routerLink]="['/chat']"></p-card>
-            <p-card class="col-4" header="Deals" [style]="{'height': '15rem', 'cursor': 'pointer'}"
-                [routerLink]="['/deals']"></p-card>
+    <!-- Metrics -->
+    <div class="metrics-grid">
+        <div class="metric-card">
+            <div class="metric-icon contests-icon">🏆</div>
+            <div class="metric-content">
+                <div class="metric-label">Active Contests</div>
+                <div class="metric-value">{{ activeContests.length }}</div>
+            </div>
+        </div>
+        <div class="metric-card">
+            <div class="metric-icon portfolio-icon">📈</div>
+            <div class="metric-content">
+                <div class="metric-label">Portfolio Value</div>
+                <div class="metric-value">{{ portfolio?.total_value ? ('$' + (portfolio.total_value | number:'1.0-0')) : '--' }}</div>
+            </div>
+        </div>
+        <div class="metric-card">
+            <div class="metric-icon total-icon">📊</div>
+            <div class="metric-content">
+                <div class="metric-label">Total Contests</div>
+                <div class="metric-value">{{ contests.length }}</div>
+            </div>
+        </div>
+        <div class="metric-card">
+            <div class="metric-icon completed-icon">✅</div>
+            <div class="metric-content">
+                <div class="metric-label">Completed</div>
+                <div class="metric-value">{{ concludedContests.length }}</div>
+            </div>
         </div>
     </div>
+
+    <!-- Active Contests -->
+    <section class="dash-section" *ngIf="activeContests.length > 0">
+        <div class="section-header">
+            <h2>Active Contests</h2>
+            <a routerLink="/contests" class="see-all">View all →</a>
+        </div>
+        <div class="cards-grid">
+            <div class="card" *ngFor="let c of activeContests" [routerLink]="['/contests', c.contest_id]">
+                <span class="badge-status badge-status--active">Active</span>
+                <h3 class="card-title">{{ c.name }}</h3>
+                <p class="card-desc">{{ c.description }}</p>
+
+                <div class="card-sponsor" *ngIf="c.sponsor_name">
+                    <img [src]="c.sponsor_logo_url" alt="" class="card-sponsor-logo" *ngIf="c.sponsor_logo_url">
+                    <span>Sponsored by <strong>{{ c.sponsor_name }}</strong></span>
+                </div>
+
+                <div class="card-stats">
+                    <div class="stat">
+                        <span class="stat-value">{{ c.participants }}/{{ c.max_participants }}</span>
+                        <span class="stat-label">PLAYERS</span>
+                    </div>
+                    <div class="stat">
+                        <span class="stat-value">{{ getDuration(c) }} days</span>
+                        <span class="stat-label">DURATION</span>
+                    </div>
+                    <div class="stat">
+                        <span class="stat-value">${{ c.starting_balance | number }}</span>
+                        <span class="stat-label">STARTING $</span>
+                    </div>
+                </div>
+
+                <div class="card-tags">
+                    <span class="tag" *ngFor="let g of c.age_groups">{{ formatAgeGroup(g) }}</span>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Portfolio Positions -->
+    <section class="dash-section" *ngIf="portfolio?.positions?.length > 0">
+        <div class="section-header">
+            <h2>Your Portfolio</h2>
+            <a routerLink="/portfolio" class="see-all">View details →</a>
+        </div>
+        <div class="positions-table">
+            <table>
+                <thead>
+                    <tr>
+                        <th>Symbol</th>
+                        <th>Shares</th>
+                        <th>Avg Cost</th>
+                        <th>Current Price</th>
+                        <th>Market Value</th>
+                        <th>Return</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr *ngFor="let pos of portfolio.positions">
+                        <td class="symbol">{{ pos.symbol }}</td>
+                        <td>{{ pos.shares }}</td>
+                        <td>{{ pos.average_cost | currency }}</td>
+                        <td>{{ pos.current_price | currency }}</td>
+                        <td><strong>{{ pos.market_value | currency }}</strong></td>
+                        <td [class.positive]="pos.return_percent > 0" [class.negative]="pos.return_percent < 0">
+                            {{ pos.return_percent > 0 ? '+' : '' }}{{ pos.return_percent | number:'1.2-2' }}%
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </section>
 </div>
-<!-- End-Panel -->

--- a/src/app/modules/dashboard/dashboard.component.ts
+++ b/src/app/modules/dashboard/dashboard.component.ts
@@ -1,18 +1,61 @@
 import { Component, OnInit } from '@angular/core';
-import { Router } from '@angular/router';
-import { DispensaryService } from 'src/app/core/dispensary/dispensary.service';
+import { AuthService } from 'src/app/core/auth/auth.service';
+import { ContestService } from 'src/app/core/contest/contest.service';
+import { PortfolioService } from 'src/app/core/portfolio/portfolio.service';
 
 @Component({
     selector: 'app-dashboard',
-    templateUrl: 'dashboard.component.html'
+    templateUrl: 'dashboard.component.html',
+    styleUrls: ['dashboard.component.css']
 })
-
 export class DashboardComponent implements OnInit {
-    name: string = 'Dispensary';
+    name = '';
+    userId = '';
+    contests: any[] = [];
+    portfolio: any = null;
+    loading = true;
 
-    constructor(private _dispensaryService: DispensaryService) { }
+    constructor(
+        private authService: AuthService,
+        private contestService: ContestService,
+        private portfolioService: PortfolioService
+    ) {}
 
     ngOnInit(): void {
-        this.name = this._dispensaryService.dispensaryName;
+        this.name = this.authService.accountUsername || '';
+        this.userId = this.authService.accountId || '';
+
+        this.contestService.list().subscribe({
+            next: (res: any) => {
+                this.contests = res.contests || [];
+                this.loading = false;
+            },
+            error: () => this.loading = false
+        });
+
+        if (this.userId) {
+            this.portfolioService.getPortfolio(this.userId).subscribe({
+                next: (res: any) => this.portfolio = res,
+                error: () => {}
+            });
+        }
+    }
+
+    get activeContests() {
+        return this.contests.filter(c => c.status === 'active');
+    }
+
+    get concludedContests() {
+        return this.contests.filter(c => c.status === 'concluded');
+    }
+
+    getDuration(c: any): number {
+        const start = new Date(c.start_date).getTime();
+        const end = new Date(c.end_date).getTime();
+        return Math.ceil((end - start) / (1000 * 60 * 60 * 24));
+    }
+
+    formatAgeGroup(g: string): string {
+        return g.replace('_', ' ').replace(/\b\w/g, c => c.toUpperCase());
     }
 }

--- a/src/app/modules/portfolio/portfolio.component.html
+++ b/src/app/modules/portfolio/portfolio.component.html
@@ -1,0 +1,112 @@
+<div class="p-4">
+    <h2 style="color: #057671;"><i class="pi pi-chart-line mr-2"></i>My Portfolio</h2>
+
+    <div *ngIf="loading" class="flex justify-content-center p-6">
+        <p-progressSpinner></p-progressSpinner>
+    </div>
+
+    <div *ngIf="!loading">
+        <!-- Portfolio Summary Cards -->
+        <div class="grid mt-3" *ngIf="portfolio">
+            <div class="col-12 md:col-4">
+                <p-card>
+                    <div class="flex flex-column align-items-center">
+                        <span style="color: #808080; font-size: 13px;">Total Value</span>
+                        <span style="font-size: 32px; font-weight: bold; color: #057671;">
+                            {{ portfolio.total_value | currency }}
+                        </span>
+                    </div>
+                </p-card>
+            </div>
+            <div class="col-12 md:col-4">
+                <p-card>
+                    <div class="flex flex-column align-items-center">
+                        <span style="color: #808080; font-size: 13px;">Cash Balance</span>
+                        <span style="font-size: 32px; font-weight: bold; color: #057671;">
+                            {{ portfolio.cash_balance | currency }}
+                        </span>
+                    </div>
+                </p-card>
+            </div>
+            <div class="col-12 md:col-4">
+                <p-card>
+                    <div class="flex flex-column align-items-center">
+                        <span style="color: #808080; font-size: 13px;">Total Return</span>
+                        <span style="font-size: 32px; font-weight: bold;" [class]="getReturnClass(totalReturn)">
+                            {{ totalReturn > 0 ? '+' : '' }}{{ totalReturn | number:'1.2-2' }}%
+                        </span>
+                    </div>
+                </p-card>
+            </div>
+        </div>
+
+        <p-tabView class="mt-4" [(activeIndex)]="activeTab">
+            <!-- Positions Tab -->
+            <p-tabPanel header="Positions">
+                <p-table [value]="portfolio?.positions || []" styleClass="p-datatable-sm p-datatable-striped" class="mt-2">
+                    <ng-template pTemplate="header">
+                        <tr>
+                            <th>Symbol</th>
+                            <th>Shares</th>
+                            <th>Avg Cost</th>
+                            <th>Current Price</th>
+                            <th>Market Value</th>
+                            <th>Gain/Loss</th>
+                            <th>Return %</th>
+                        </tr>
+                    </ng-template>
+                    <ng-template pTemplate="body" let-pos>
+                        <tr>
+                            <td><b>{{ pos.symbol }}</b></td>
+                            <td>{{ pos.shares | number: sharesFormat(pos.asset_class) }}</td>
+                            <td>{{ pos.average_cost | currency }}</td>
+                            <td>{{ pos.current_price | currency }}</td>
+                            <td><b>{{ pos.market_value | currency }}</b></td>
+                            <td [class]="getReturnClass(pos.market_value - (pos.average_cost * pos.shares))">
+                                {{ (pos.market_value - (pos.average_cost * pos.shares)) | currency }}
+                            </td>
+                            <td [class]="getReturnClass(pos.return_percent)">
+                                <b>{{ pos.return_percent > 0 ? '+' : '' }}{{ pos.return_percent | number:'1.2-2' }}%</b>
+                            </td>
+                        </tr>
+                    </ng-template>
+                    <ng-template pTemplate="emptymessage">
+                        <tr><td colspan="7" class="text-center p-4" style="color: #808080;">No positions yet. Start trading to build your portfolio!</td></tr>
+                    </ng-template>
+                </p-table>
+            </p-tabPanel>
+
+            <!-- Transactions Tab -->
+            <p-tabPanel header="Transaction History">
+                <p-table [value]="transactions" styleClass="p-datatable-sm p-datatable-striped" class="mt-2"
+                         [paginator]="transactions.length > 10" [rows]="10">
+                    <ng-template pTemplate="header">
+                        <tr>
+                            <th>Date</th>
+                            <th>Type</th>
+                            <th>Symbol</th>
+                            <th>Shares</th>
+                            <th>Price</th>
+                            <th>Total</th>
+                        </tr>
+                    </ng-template>
+                    <ng-template pTemplate="body" let-tx>
+                        <tr>
+                            <td>{{ tx.created_at | date:'short' }}</td>
+                            <td>
+                                <p-badge [value]="tx.type | titlecase" [severity]="tx.type === 'buy' ? 'success' : 'danger'"></p-badge>
+                            </td>
+                            <td><b>{{ tx.symbol }}</b></td>
+                            <td>{{ tx.shares | number: sharesFormat(tx.asset_class) }}</td>
+                            <td>{{ tx.price | currency }}</td>
+                            <td>{{ tx.total | currency }}</td>
+                        </tr>
+                    </ng-template>
+                    <ng-template pTemplate="emptymessage">
+                        <tr><td colspan="6" class="text-center p-4" style="color: #808080;">No transactions yet.</td></tr>
+                    </ng-template>
+                </p-table>
+            </p-tabPanel>
+        </p-tabView>
+    </div>
+</div>

--- a/src/app/modules/portfolio/portfolio.component.ts
+++ b/src/app/modules/portfolio/portfolio.component.ts
@@ -1,0 +1,55 @@
+import { Component, OnInit } from '@angular/core';
+import { AuthService } from 'src/app/core/auth/auth.service';
+import { PortfolioService } from 'src/app/core/portfolio/portfolio.service';
+
+@Component({
+    selector: 'app-portfolio',
+    templateUrl: 'portfolio.component.html'
+})
+export class PortfolioComponent implements OnInit {
+    portfolio: any = null;
+    transactions: any[] = [];
+    loading = true;
+    activeTab = 0;
+
+    constructor(
+        private authService: AuthService,
+        private portfolioService: PortfolioService
+    ) {}
+
+    ngOnInit(): void {
+        const userId = this.authService.accountId;
+        if (!userId) return;
+
+        this.portfolioService.getPortfolio(userId).subscribe({
+            next: (res: any) => {
+                this.portfolio = res;
+                this.loading = false;
+            },
+            error: () => this.loading = false
+        });
+
+        this.portfolioService.getTransactions(userId).subscribe({
+            next: (res: any) => this.transactions = res.transactions || res || [],
+            error: () => {}
+        });
+    }
+
+    getReturnClass(val: number): string {
+        if (val > 0) return 'text-green-600';
+        if (val < 0) return 'text-red-600';
+        return '';
+    }
+
+    sharesFormat(assetClass?: string): string {
+        return (assetClass || '').toLowerCase() === 'crypto' ? '1.6-6' : '1.4-4';
+    }
+
+    get totalReturn(): number {
+        if (!this.portfolio?.positions?.length) return 0;
+        const totalCost = this.portfolio.positions.reduce((s: number, p: any) => s + (p.average_cost * p.shares), 0);
+        const totalValue = this.portfolio.positions.reduce((s: number, p: any) => s + p.market_value, 0);
+        if (totalCost === 0) return 0;
+        return ((totalValue - totalCost) / totalCost) * 100;
+    }
+}

--- a/src/app/modules/portfolio/portfolio.module.ts
+++ b/src/app/modules/portfolio/portfolio.module.ts
@@ -1,0 +1,16 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { PrimeNgModule } from 'src/app/shared/prime-ng.module';
+
+import { PortfolioComponent } from './portfolio.component';
+
+@NgModule({
+    declarations: [PortfolioComponent],
+    imports: [
+        CommonModule,
+        RouterModule.forChild([{ path: '', component: PortfolioComponent }]),
+        PrimeNgModule
+    ]
+})
+export class PortfolioModule {}

--- a/src/app/modules/trading/trading.component.html
+++ b/src/app/modules/trading/trading.component.html
@@ -1,0 +1,65 @@
+<div class="p-4">
+    <h2 style="color: #057671;"><i class="pi pi-dollar mr-2"></i>Trading</h2>
+
+    <div class="grid mt-4">
+        <div class="col-12 md:col-8">
+            <p-card header="Place a Trade" [style]="{'border-left': '4px solid #057671'}">
+                <p style="color: #808080; font-size: 14px; margin-bottom: 20px;">
+                    Search for stocks and place paper trades for your contest portfolios.
+                </p>
+
+                <div class="flex flex-column gap-3">
+                    <div class="p-inputgroup">
+                        <span class="p-inputgroup-addon"><i class="pi pi-search"></i></span>
+                        <input pInputText placeholder="Search for a stock (e.g., AAPL, NVDA, TSLA)" />
+                    </div>
+
+                    <div class="grid">
+                        <div class="col-6">
+                            <label style="font-size: 13px; color: #808080;">Action</label>
+                            <p-selectButton [options]="[{label: 'Buy', value: 'buy'}, {label: 'Sell', value: 'sell'}]"
+                                            styleClass="mt-1"></p-selectButton>
+                        </div>
+                        <div class="col-6">
+                            <label style="font-size: 13px; color: #808080;">Shares</label>
+                            <input pInputText type="number" placeholder="0" class="mt-1 w-full" />
+                        </div>
+                    </div>
+
+                    <button pButton label="Preview Order" icon="pi pi-check"
+                            [style]="{background: '#057671', border: 'none'}" class="mt-2"
+                            [disabled]="true"></button>
+                </div>
+
+                <p style="color: #E19A3D; font-size: 13px; margin-top: 15px;">
+                    <i class="pi pi-info-circle mr-1"></i>
+                    Trading functionality coming soon. Portfolio data is available on the Portfolio page.
+                </p>
+            </p-card>
+        </div>
+
+        <div class="col-12 md:col-4">
+            <p-card header="Market Status" [style]="{'border-left': '4px solid #E19A3D'}">
+                <div class="flex flex-column gap-3">
+                    <div class="flex justify-content-between">
+                        <span style="color: #808080;">Market</span>
+                        <p-badge value="Closed" severity="danger"></p-badge>
+                    </div>
+                    <div class="flex justify-content-between">
+                        <span style="color: #808080;">Paper Trading</span>
+                        <p-badge value="Active" severity="success"></p-badge>
+                    </div>
+                </div>
+            </p-card>
+
+            <p-card header="Quick Tips" class="mt-3">
+                <ul style="color: #808080; font-size: 13px; padding-left: 20px; line-height: 2;">
+                    <li>Start with your $10,000 virtual balance</li>
+                    <li>Diversify across multiple stocks</li>
+                    <li>Check the leaderboard regularly</li>
+                    <li>Trades execute at current market price</li>
+                </ul>
+            </p-card>
+        </div>
+    </div>
+</div>

--- a/src/app/modules/trading/trading.component.ts
+++ b/src/app/modules/trading/trading.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'app-trading',
+    templateUrl: 'trading.component.html'
+})
+export class TradingComponent {}

--- a/src/app/modules/trading/trading.module.ts
+++ b/src/app/modules/trading/trading.module.ts
@@ -1,0 +1,16 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { PrimeNgModule } from 'src/app/shared/prime-ng.module';
+
+import { TradingComponent } from './trading.component';
+
+@NgModule({
+    declarations: [TradingComponent],
+    imports: [
+        CommonModule,
+        RouterModule.forChild([{ path: '', component: TradingComponent }]),
+        PrimeNgModule
+    ]
+})
+export class TradingModule {}


### PR DESCRIPTION
## Summary

Rewrites the user-facing beanstalk-web app from a dispensary orientation to a trading-contest orientation. Migrates sign-in to the unified auth API, introduces feature modules for portfolio, contests, and trading, replaces the dispensary dashboard with a contest + portfolio overview, and rebrands the sidebar and nav to match. Admin timezone-aware contest creation is included as the backend/admin counterpart so the new consumer-facing contest flows have well-scheduled contests to browse.

## Commits

In branch order (oldest → newest):

1. **`73b0fd3` feat(admin): add timezone support to contest creation** — adds a timezone dropdown (ET/CT/MT/PT/HT/UTC) to the admin contest creation form and renders the short timezone code alongside duration on contest cards. Hardens `getDuration()` against malformed or missing dates.
2. **`0452dab` feat(auth): migrate sign-in to unified user auth API** — switches sign-in from `/web/auth/dispensary/signin` to `/api/auth/login` and renames form fields `dispensary_email/password` → `email/password`. Response parsing updated for flat `user_id`/`name` shape. `DispensaryService` is intentionally kept as a compat shim for remaining call sites.
3. **`9c9cb02` feat(portfolio): add portfolio service and module** — introduces `PortfolioService` and the user-facing portfolio view (summary cards, positions table, transaction history). Shares render via Angular `DecimalPipe` with per-asset-class precision (4 for stock/ETF, 6 for crypto) — see the Notes section.
4. **`a903bc9` feat(contests): add contest service with list and detail views** — introduces `ContestService` and the contests feature module (list, detail, routing). The detail view also renders a sponsor card (`sponsor_name`, `sponsor_logo_url`, `sponsor_tagline`) when those fields are present on the contest payload.
5. **`e7ee2cb` feat(trading): add trading module** — scaffolds the user-facing trading module (component + template + module). Functional trading flows land in a follow-up.
6. **`9bf3447` feat(dashboard): replace dispensary dashboard with contests and portfolio overview** — rewrites the user dashboard to pull active/concluded contests via `ContestService` and portfolio state via `PortfolioService`, replacing the `DispensaryService`-backed dispensary dashboard.
7. **`27d3299` feat(layout): rebrand sidebar and rewire nav for contests/portfolio/trading** — removes dispensary/deals/chat routes in favor of contests/portfolio/trading, redesigns the sidebar with brand mark and user avatar/logout, and simplifies the layout shell (header component removed).

## Test plan

- [ ] **Sign-in** — log in via `/sign-in` against the new `/api/auth/login` endpoint. Verify the form accepts `email` + `password`, the response parses the flat `user_id`/`name` shape, and the user lands on the dashboard.
- [ ] **Dashboard renders new services** — confirm the dashboard renders active/concluded contests and portfolio summary via `ContestService` + `PortfolioService` (no residual `DispensaryService` calls in the dashboard path).
- [ ] **`/contests` list + detail** — navigate to `/contests`, verify the list renders. Click through to a contest detail; verify header, stats cards (players, starting balance, days remaining), and the leaderboard render. If any contest in test data has sponsor fields, verify the sponsor card appears; otherwise, verify the card is cleanly omitted.
- [ ] **`/portfolio` with decimal formatting** — navigate to `/portfolio`. Verify positions render with shares at **4 decimals for stock/ETF** rows and **6 decimals for crypto** rows. Same for transaction history. If any row is missing `asset_class`, verify it falls back to 4 decimals without error.
- [ ] **Sidebar nav reaches new routes** — verify the new sidebar navigates to `/dashboard`, `/contests`, `/portfolio`, and `/trading`. Confirm the old dispensary/deals/chat links are gone. Verify avatar + logout render correctly.
- [ ] **Admin: timezone-aware contest creation** (from `73b0fd3`) — open the admin contest manager, create a contest with a non-local timezone (e.g., ET when testing from PT). Verify the contest card renders the short timezone code (e.g., `ET`) alongside duration. Verify `getDuration()` handles a contest with missing/malformed dates without throwing.

## Known follow-up

**Timezone asymmetry in consumer-facing contest rendering.** The admin side (`73b0fd3`) schedules contests in an explicit timezone, but `contest-detail.component.ts:getDaysRemaining()` does raw `new Date(...).getTime()` math with no timezone handling. Users see the countdown in their local browser time regardless of the admin-selected timezone. Low-impact in single-timezone test environments; will surface at the first cross-timezone demo or deploy.

Tracked as #1. Fix is to apply the same timezone library the admin side uses to all consumer-facing contest time rendering — `getDaysRemaining()` plus any other `new Date(...)` / `.getTime()` usages in contest-facing components (`contest-detail`, `contest-list`, `dashboard`).

## Notes

- **Fractional share decimal formatting matches the mobile policy established 2026-04-20** — all asset classes are fractional, with stocks/ETFs displayed to 4 decimals and crypto to 6. The portfolio view implements this via a small `sharesFormat(assetClass)` helper that is **case-insensitive** on the `asset_class` value (backend sends uppercase per Alpaca convention).
- `DispensaryService` is intentionally retained as a compat shim in the auth migration commit. Any remaining call sites will be removed in a follow-up once the full dispensary path is audited.