### PR TITLE
Contest manager: add Prize entry (populate structured prizes[])

### DIFF
--- a/src/app/modules/admin/contest-manager/contest-manager.component.html
+++ b/src/app/modules/admin/contest-manager/contest-manager.component.html
@@ -236,6 +236,29 @@
         </div>
       </fieldset>
 
+      <!-- Prizes -->
+      <fieldset>
+        <legend>Prizes <span class="legend-hint">(shown on the contest's Prize tile in the app)</span></legend>
+        <div class="field" *ngFor="let prize of newContest.prizes; let i = index">
+          <div class="field-row">
+            <div class="field">
+              <label>Place</label>
+              <input type="number" min="1" [(ngModel)]="prize.prize_rank" [name]="'prize_rank_' + i" />
+            </div>
+            <div class="field">
+              <label>Prize</label>
+              <input type="text" [(ngModel)]="prize.prize_value" [name]="'prize_value_' + i"
+                     placeholder="e.g. $50 STEP credit" />
+            </div>
+            <button type="button" class="btn btn-outline btn-sm" style="align-self: flex-end;"
+                    (click)="removePrize(i)">Remove</button>
+          </div>
+          <input type="text" [(ngModel)]="prize.prize_description" [name]="'prize_desc_' + i"
+                 placeholder="Description (optional) — e.g. $50 deposited to your STEP account" />
+        </div>
+        <button type="button" class="btn btn-outline btn-sm" (click)="addPrize()">+ Add Prize</button>
+      </fieldset>
+
       <!-- Sponsor -->
       <fieldset>
         <legend>Sponsor <span class="legend-hint">(optional)</span></legend>

--- a/src/app/modules/admin/contest-manager/contest-manager.component.ts
+++ b/src/app/modules/admin/contest-manager/contest-manager.component.ts
@@ -129,7 +129,33 @@ export class ContestManagerComponent implements OnInit {
     });
   }
 
+  addPrize(): void {
+    this.newContest.prizes = [
+      ...(this.newContest.prizes || []),
+      {
+        prize_rank: (this.newContest.prizes?.length || 0) + 1,
+        prize_type: 'cash',
+        prize_value: '',
+        prize_description: '',
+      },
+    ];
+  }
+
+  removePrize(index: number): void {
+    this.newContest.prizes = (this.newContest.prizes || []).filter(
+      (_: any, i: number) => i !== index
+    );
+  }
+
   saveContest(): void {
+    // Drop empty prize rows so blanks never reach the API (and the app's Prize
+    // tile). A prize counts only if it has a value or a description.
+    this.newContest.prizes = (this.newContest.prizes || []).filter(
+      (p: any) =>
+        (p?.prize_value && `${p.prize_value}`.trim()) ||
+        (p?.prize_description && `${p.prize_description}`.trim())
+    );
+
     if (this.editingContestId) {
       this.http.put<any>(`${environment.baseUrl}/api/contests/${this.editingContestId}`, this.newContest).subscribe({
         next: (updated) => {


### PR DESCRIPTION
## Problem

The contest create/edit form had **no prize input**. The form model carried `prizes: []` but nothing ever populated it, so every contest was saved with an empty `prizes[]`. The mobile app's **Prize tile** reads the structured `prizes[0].prize_value` / `prize_description`, so it showed a dash (`—`) even for contests whose description mentioned a cash prize (e.g. STEPtember's "$50").

## Change

`src/app/modules/admin/contest-manager/contest-manager.component.*`:
- Add a repeatable **Prizes** section to the form — each row is Place (`prize_rank`), Prize (`prize_value`, e.g. `$50`), and an optional Description (`prize_description`) — bound to `newContest.prizes`.
- `addPrize()` / `removePrize(i)` helpers.
- `saveContest()` strips empty prize rows before the POST/PUT so blanks never reach the API.
- Existing prizes already load on edit (`openEdit` maps `d.prizes`), so a prize can be added to an existing contest too.

This maps 1:1 to the API's stored shape (`prizes[].prize_type/prize_value/prize_description`), which the mobile app already renders — no API or app change needed.

## Testing / caveat

⚠️ Not built here — this environment has no Angular toolchain. The change follows the file's existing template-driven (`[(ngModel)]`) patterns and styling classes; please `npm ci && ng build` (or `ng serve`) and eyeball the form before merging. To verify end-to-end: add a prize to a contest, save, and confirm the mobile Prize tile shows it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CpHFsodt3E1hPkhrAxeAb7)_